### PR TITLE
Update dev guides; Add self-publishing workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Rule for markdown files
+*.md        @ionut-arm @hug-dev
+
+# Rule for GitHub-specific files
+.github/*   @ionut-arm @hug-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Build Github mdBook
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install mdbook
+      run: cargo install mdbook
+    - name: Build book
+      run: mdbook build
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./book

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 book
+*patch
+*DS_Store

--- a/src/dev_guides/README.md
+++ b/src/dev_guides/README.md
@@ -1,0 +1,25 @@
+<!--
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
+  -- SPDX-License-Identifier: Apache-2.0
+  --
+  -- Licensed under the Apache License, Version 2.0 (the "License"); you may
+  -- not use this file except in compliance with the License.
+  -- You may obtain a copy of the License at
+  --
+  -- http://www.apache.org/licenses/LICENSE-2.0
+  --
+  -- Unless required by applicable law or agreed to in writing, software
+  -- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  -- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -- See the License for the specific language governing permissions and
+  -- limitations under the License.
+--->
+
+# Developer guides
+
+These notes are meant as a guide for those looking to work hands-on with the Parsec service source code. They cover the following concepts:
+
+* [Building](build.md) - description of the options that can be used for building the service and how they relate to the build environment
+* [Testing](test.md) - details about the kinds of tests we employ and how to set up your environment in preparation for running them
+* [Writing a client](writing_library.md) - guide for implementing a new client library
+* [Writing a provider](adding_provider.md) - guide for implementing a new provider that will add Parsec support for new platforms

--- a/src/dev_guides/adding_provider.md
+++ b/src/dev_guides/adding_provider.md
@@ -1,5 +1,5 @@
 <!--
-  -- Copyright (c) 2019, Arm Limited, All Rights Reserved
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
   -- SPDX-License-Identifier: Apache-2.0
   --
   -- Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -17,4 +17,12 @@
 
 # Adding a new Parsec Provider
 
-To be written!
+Creating new providers means enabling Parsec to work on new platforms and is one of the main goals of the project. As such, the interface that must be implemented by each provider was built with modularity in mind, allowing developers to choose which operations they implement and when. This interface is represented by a Rust [`trait`](https://doc.rust-lang.org/book/ch10-02-traits.html) - more precisely, the [`Provide`](https://github.com/parallaxsecond/parsec/blob/master/src/providers/mod.rs) trait.
+
+The full list of operations that can be implemented can be found in the link above and will be expanded as the project progresses towards supporting more use cases.
+
+Apart from `list_opcodes` and `describe`, no method is mandatory and client libraries are expected to use these two operations to bootstrap their usage of the service. Thus, once an operation is correctly supported, its opcode can be added to those returned by `list_opcodes`. Any operation that is not implemented will return a response code of `UnsupportedOperation` by default.
+
+Each provider must offer a description of itself in the shape of a [`ProviderInfo`](https://github.com/parallaxsecond/parsec-interface-rs/blob/master/src/operations/list_providers.rs) value, by implementing the `describe` method. The UUID identifying the provider is developer-generated and should not clash with existing providers. This process also requires the new provider to be added to the [`ProviderID`](https://github.com/parallaxsecond/parsec-interface-rs/blob/master/src/requests/mod.rs) enum.
+
+Lots of care must be taken when implementing operations that the inputs and outputs are in the correct format, especially in the case of byte arrays. Detailed description of all input and output can be found in the [operations documentation](../parsec/operations/README.md).

--- a/src/dev_guides/build.md
+++ b/src/dev_guides/build.md
@@ -1,5 +1,5 @@
 <!--
-  -- Copyright (c) 2019, Arm Limited, All Rights Reserved
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
   -- SPDX-License-Identifier: Apache-2.0
   --
   -- Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -18,7 +18,20 @@
 # How to build Parsec
 
 This project is coded in the Rust Programming Language. To build it, you first need to [install Rust](https://www.rust-lang.org/tools/install).
-To build and run the service, execute `cargo run`. `parsec` will then wait for clients.
+
+Because the providers supported by Parsec are dependent on libraries and/or hardware features present on the platform, the build is fragmented through Rust features so that the resulting binary only contains the desired providers. Currently the service provides the following features: `mbed-crypto-provider`, `pkcs11-provider`, and `tpm-provider`.
+
+In order for the service to be spun up, a number of parameters are required in a TOML file. The repository contains an [example](https://github.com/parallaxsecond/parsec/blob/master/config.toml) of such a configuration file which shows all the options and their default values.
+
+To build and run the service, set `DESIRED_FEATURES` to be a subset of the features mentioned above, space or comma separated, and execute:
+```bash
+cargo run --no-default-features --features $DESIRED_FEATURES
+```
+
+`parsec` will then construct the service based on the configuration file and wait for clients. If the configuration file is not in the directory from which Parsec is run, its path must be passed via CLI:
+```bash
+cargo run --no-default-features --features $DESIRED_FEATURES -- --config $PATH_TO_CONFIG
+```
 
 To cross-compile the service for the Linux on Arm64 target, you will need to install the
 appropriate toolchain for this target. By default the Arm GNU toolchain is used to

--- a/src/dev_guides/test.md
+++ b/src/dev_guides/test.md
@@ -1,5 +1,5 @@
 <!--
-  -- Copyright (c) 2019, Arm Limited, All Rights Reserved
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
   -- SPDX-License-Identifier: Apache-2.0
   --
   -- Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -17,11 +17,26 @@
 
 # How to test Parsec
 
-The `tests/all.sh` script executes all tests. [`rustfmt`](https://github.com/rust-lang/rustfmt)
-and [`clippy`](https://github.com/rust-lang/rust-clippy) are needed.
+Parsec relies on a mix of unit, integration, stress and fuzz tests. Unit tests are usually found in the same module as the code they verify. Integration tests can be found in the `tests` directory (along with the code framework required for running them), and come in two flavours: single-provider and all-providers.
 
-You can execute unit tests with `cargo test --lib`.
+Single-provider tests do a thorough verification of each individual provider, while all-providers tests check that the common functionality is capable of supporting multiple providers at the same time. Another subcategory of integration tests are persistance tests which check that key material is persisted through service restarts.
+
+The stress test simply constructs and sends random requests as fast as possible using a multithreaded client. Valid requests are sent intermittently so as to check that the service is still up and working correctly.
+
+The `tests/ci.sh` script executes all tests. [`rustfmt`](https://github.com/rust-lang/rustfmt)
+and [`clippy`](https://github.com/rust-lang/rust-clippy) are needed for code formatting and static checks.
+
+You can execute unit tests with `cargo test --lib` or stress tests with `cargo test stress_test`.
 
 The [test client](https://github.com/parallaxsecond/parsec-client-test) is used for integration
 testing. Check that repository for more details.
 
+## Fuzz testing
+
+Fuzz testing works, at the moment, on a service level, generating random requests and sending them to be processed. Running the fuzz tests can be done through the `fuzz.sh` script in the root of the repository. 
+
+`./fuzz.sh run` builds a Docker image where the fuzz tests will run. It then sets up the environment and initiates the test in the container. The fuzzing engine ([libFuzzer](http://llvm.org/docs/LibFuzzer.html)) works by generating random inputs for a fuzzing target and then observing the code segments reached using said input.
+
+To stop the fuzzer, simply run `./fuzz.sh stop`. To view the logs of a currently executing fuzzer, run `./fuzz.sh follow`.
+
+Any crashes or slow tests, as well as tests that lead to a timeout, are stored in `./fuzz/artifacts/fuzz_service/`.

--- a/src/parsec/operations/list_opcodes.md
+++ b/src/parsec/operations/list_opcodes.md
@@ -1,5 +1,5 @@
 <!--
-  -- Copyright (c) 2019, Arm Limited, All Rights Reserved
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
   -- SPDX-License-Identifier: Apache-2.0
   --
   -- Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -19,7 +19,7 @@
 
 ## **Summary**
 
-Gets a list of available opcodes supported by a PARSEC provider.
+Gets a list of available opcodes supported by a Parsec provider.
 
 ## **Contract**
 

--- a/src/parsec/operations/list_providers.md
+++ b/src/parsec/operations/list_providers.md
@@ -1,5 +1,5 @@
 <!--
-  -- Copyright (c) 2019, Arm Limited, All Rights Reserved
+  -- Copyright (c) 2020, Arm Limited, All Rights Reserved
   -- SPDX-License-Identifier: Apache-2.0
   --
   -- Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -19,7 +19,7 @@
 
 ## **Summary**
 
-Gets a list of available PARSEC providers to be used by clients.
+Gets a list of available Parsec providers to be used by clients.
 
 ## **Contract**
 


### PR DESCRIPTION
This commit adds updates to the developer guides part of the docs, bringing
them up to speed with the state of the service.
It also adds a GitHub Actions workflow that builds and publishes the
documentation after each push to master.

closes #1 
