### PR TITLE
Add clients API coverage page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,7 +2,8 @@
 
 - [Introduction](README.md)
 - [Overview](overview.md)
-- [API coverage](api_coverage.md)
+- [Service API coverage](service_api_coverage.md)
+- [Clients API coverage](clients_api_coverage.md)
 - [Parsec Threat Model](threat_model/threat_model.md)
 - [Parsec Rust client Threat Model](threat_model/rust_client_threat_model.md)
 - [Parsec for users](parsec_users.md)

--- a/src/clients_api_coverage.md
+++ b/src/clients_api_coverage.md
@@ -1,0 +1,70 @@
+# Parsec API coverage within client libraries
+
+The current interface contracts defined for communication between Parsec and its clients is tracking
+the [PSA Cryptography API version
+1.0](https://developer.arm.com/architectures/security-architectures/platform-security-architecture/documentation).
+This page describes the current state of support within clients for the operations, attributes and
+options that are defined in that specification and for Parsec-related functionality (e.g. support
+for various providers).
+
+For an overview of the functionality supported by the service, see the [service API coverage
+page](service_api_coverage.md).
+
+**Note:** Only client libraries that are developed by the Parsec organisation are represented in the
+tables below. This does not guarantee or imply the same amount of support within other libraries. We
+encourage each library author to publish their own coverage figures in their format of choice. Links
+will be added here for any other such coverage report.
+
+## Provider support
+
+| Provider    | Rust client |
+|-------------|-------------|
+| Mbed Crypto | ✅         |
+| PKCS11      | ✅         |
+| TPM 2.0     | ✅         |
+
+## Operation support
+
+| Operation         | Rust client |
+|-------------------|-------------|
+| Import key        | ✅         |
+| Generate key      | ✅         |
+| Export public key | ✅         |
+| Destroy key       | ✅         |
+| Sign hash         | ✅         |
+| Verify hash       | ✅         |
+
+## Algorithm support
+
+### Hash algorithms
+
+| Algorithm   | Rust client |
+|-------------|-------------|
+| MD2         | ✅         |
+| MD4         | ✅         |
+| MD5         | ✅         |
+| RIPEMD160   | ✅         |
+| SHA-1       | ✅         |
+| SHA-224     | ✅         |
+| SHA-256     | ✅         |
+| SHA-384     | ✅         |
+| SHA-512     | ✅         |
+| SHA-512-224 | ✅         |
+| SHA-512-256 | ✅         |
+| SHA3-224    | ✅         |
+| SHA3-256    | ✅         |
+| SHA3-384    | ✅         |
+| SHA3-512    | ✅         |
+
+### Asymmetric signing algorithms
+
+| Algorithm              | Rust client |
+|------------------------|-------------|
+| RSA PKCS 1v5 with hash | ✅         |
+| Raw RSA PKCS 1v5       | ✅         |
+| RSA PSS                | ✅         |
+| ECDSA                  | ✅         |
+| ECDSA with any hash    | ✅         |
+| Deterministic ECDSA    | ✅         |
+
+*Copyright 2020 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/psa_algorithm.md
+++ b/src/parsec_client/operations/psa_algorithm.md
@@ -7,8 +7,8 @@ Some of the algorithms defined here are deprecated and should not be used withou
 is at the discretion of the system administrator whether those algorithms are permitted or not.
 
 **Notice:** not all possible algorithms are currently supported by Parsec. Please see the [API
-coverage](../../api_coverage.md) for an overview of what Parsec currently supports. Some of the
-attributes might not be supported by some providers as it is not in their interface.
+coverage](../../service_api_coverage.md) for an overview of what Parsec currently supports. Some of
+the attributes might not be supported by some providers as it is not in their interface.
 
 ## Algorithm type
 

--- a/src/parsec_client/operations/psa_key_attributes.md
+++ b/src/parsec_client/operations/psa_key_attributes.md
@@ -7,8 +7,8 @@ Some of the algorithms defined here are deprecated and should not be used withou
 is at the discretion of the system administrator whether those algorithms are permitted or not.
 
 **Notice:** not all possible attributes are currently supported by Parsec. Please see the [API
-coverage](../../api_coverage.md) for an overview of what Parsec currently supports. Some of the
-attributes might not be supported by some providers as it is not in their interface.
+coverage](../../service_api_coverage.md) for an overview of what Parsec currently supports. Some of
+the attributes might not be supported by some providers as it is not in their interface.
 
 ## KeyAttributes type
 

--- a/src/service_api_coverage.md
+++ b/src/service_api_coverage.md
@@ -12,8 +12,8 @@ that are defined in that specification. It covers two different sides of the iss
 - Coverage of the operations and key attributes implemented for each provider (that is offered as
    part of the Parsec service).
 
-**NOTE:** This does not guarantee or imply the same amount of support within client libraries. We
-encourage each library to publish its own coverage figures in their format of choice.
+**NOTE:** This is not a representation of the coverage available to clients using any particular
+programming language. In that regard see the [clients API coverage page](clients_api_coverage.md).
 
 ## IPC operations coverage
 
@@ -87,7 +87,6 @@ option marked as supported is necessarily supported for all operations on which 
 | SHA3-256    | ❌                  | ❌              | ✅              |
 | SHA3-384    | ❌                  | ❌              | ✅              |
 | SHA3-512    | ❌                  | ❌              | ✅              |
-| Any hash    | ❌                  | ❌              | ❌              |
 
 #### Asymmetric signing algorithms
 


### PR DESCRIPTION
This commit adds a new page to the book describing the API coverage of
the client libraries.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>