### PR TITLE
Add a notion of priority in ListProviders

### DIFF
--- a/src/parsec_client/operations/list_providers.md
+++ b/src/parsec_client/operations/list_providers.md
@@ -1,6 +1,6 @@
 # ListProviders
 
-Gets a list of available Parsec providers to be used by clients. Opcode: 8 (`0x0008`)
+Gets a prioritised list of available Parsec providers to be used by clients. Opcode: 8 (`0x0008`)
 
 ## Parameters
 
@@ -35,6 +35,11 @@ No specific response status codes returned.
 The version triplet returned by this operation (`version_maj`, `version_min` and `version_rev`) is
 the implementation version of the specific Parsec provider. For the Core Provider, this version is
 the implementation version of the whole Parsec service.
+
+The `providers` vector returned is in order of provider priority: the highest priority providers
+come first. The core provider will always come last. The provider at position zero, if not the core
+provider, can be treated as default provider by the client. Clients should still check the supported
+opcodes of the provider, even the default one, as it might not implement the operations they want.
 
 ## Contract
 

--- a/src/parsec_service/test.md
+++ b/src/parsec_service/test.md
@@ -108,7 +108,8 @@ IBM Software TPM. You will need to follow these steps:
 - install the TSS libraries ([installation
    guide](https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md)). Parsec has been tested
    with version 2.3.3.
-- install the [TPM tools](https://github.com/tpm2-software/tpm2-tools)
+- install the [TPM tools](https://github.com/tpm2-software/tpm2-tools). Parsec has been tested with
+   version 4.1.
 - install the [Software TPM](https://sourceforge.net/projects/ibmswtpm2/), run `make` in the `src`
    directory. It will build the `tpm_server` executable.
 - install Parsec with the `tpm-provider` feature: `cargo build --features tpm-provider`.


### PR DESCRIPTION
The ListProviders now returns providers in order of priority.
See parallaxsecond/parsec-se-driver#7 for details.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>