### PR TITLE
Update the installation guide

### DIFF
--- a/src/parsec_service/install_parsec_linux.md
+++ b/src/parsec_service/install_parsec_linux.md
@@ -15,28 +15,6 @@ can be a space or comma-separated subset of: `mbed-crypto-provider`, `pkcs11-pro
 `tpm-provider`. Choose the providers you want to install depending on what is available on the
 platform.
 
-Create and log in to a new user named `parsec`.
-
-```
-sudo useradd -m parsec
-sudo passwd parsec
-su --login parsec
-```
-
-In its home directory, pull and install Parsec as a daemon.
-
-```
-git clone https://github.com/parallaxsecond/parsec.git
-cargo install --features $DESIRED_FEATURES --path parsec
-```
-
-Copy and adapt the [configuration](configuration.md) you want to use. For a secure deployment, make
-sure to activate the `log_error_details` option and to use a `trace` log level.
-
-```
-cp parsec/config.toml config.toml
-```
-
 Create the Parsec socket directory.
 
 ```
@@ -53,10 +31,46 @@ sudo chown :parsec-clients /tmp/parsec
 sudo chmod 750 /tmp/parsec
 ```
 
+For example, adding the imaginary `parsec-client-1` user to the `parsec-clients` group:
+
+```
+sudo usermod -a -G parsec-clients parsec-client-1
+```
+
+Users just added to that group might need to log-out and log-in again to make sure the change apply.
+
 In a deployment **with an Identity Provider**, set the correct permissions on the socket folder.
 
 ```
 sudo chmod 755 /tmp/parsec
+```
+
+Create and log in to a new user named `parsec`.
+
+```
+sudo useradd -m parsec
+sudo passwd parsec
+su --login parsec
+```
+
+Depending on which features of Parsec the `parsec` user is going to use, it might need to be given
+more privileges in order to access some resources on the system. Refer to the
+[Providers](providers.md) page for more information.
+
+In its home directory, pull and install Parsec as a daemon. If a Rust toolchain is not available
+widely on the system, it will need to be [installed](https://www.rust-lang.org/tools/install) for
+that specific user.
+
+```
+git clone https://github.com/parallaxsecond/parsec.git
+cargo install --features $DESIRED_FEATURES --path parsec
+```
+
+Copy and adapt the [configuration](configuration.md) you want to use. For a secure deployment, make
+sure to activate the `log_error_details` option and to use a `trace` log level.
+
+```
+cp parsec/config.toml config.toml
 ```
 
 Install the systemd unit files and activate the Parsec socket.
@@ -68,12 +82,16 @@ systemctl --user enable parsec
 systemctl --user start parsec
 ```
 
-`parsec-clients` users (with no IP) or every one (with IP) can now use Parsec! You can test it going
-inside the `parsec/e2e_tests` directory and:
+`parsec-clients` users (with no IP) or every one (with IP) can now use Parsec! You can test it
+(having logged in a `parsec-clients` user) going inside the `parsec/e2e_tests` directory and:
 
 ```
 cargo test normal_tests
 ```
+
+*Note:* if you encounter a "Permission Denied" error while executing the end-to-end tests, make sure
+that the group change has taken effect. You can check it by calling `groups` with no arguments. If
+you do not see `parsec-clients`, please try logging the user out and in again to apply the change.
 
 Check the Parsec logs with:
 


### PR DESCRIPTION
* move the commands needing `sudo` at the beginning so that they are done by the admin
* inform that rust might need to be installed in the `parsec` user
* add an example command to add an user to the `parsec-clients` group
* inform that log-out/log-in might be needed
* inform that priviliges might need to be set for the `parsec` user

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>