### PR TITLE
Fix formatting and add clarifications from 1.0.1

### DIFF
--- a/src/parsec_client/operations/psa_aead_decrypt.md
+++ b/src/parsec_client/operations/psa_aead_decrypt.md
@@ -1,6 +1,6 @@
 # PsaAeadDecrypt
 
-Process and authenticated decryption operation. Opcode: 18 (`0x0012`)
+Process an authenticated decryption operation. Opcode: 18 (`0x0012`)
 
 ## Parameters
 
@@ -33,7 +33,8 @@ Process and authenticated decryption operation. Opcode: 18 (`0x0012`)
 
 ## Description
 
-Authenticates and decrypts the given data using the given AEAD algorithm.
+Authenticates and decrypts the given data using the given AEAD algorithm. Process an authenticated
+decryption operation.
 
 ## Contract
 

--- a/src/parsec_client/operations/psa_aead_encrypt.md
+++ b/src/parsec_client/operations/psa_aead_encrypt.md
@@ -1,6 +1,6 @@
 # PsaAeadEncrypt
 
-Process and authenticated encryption operation. Opcode: 17 (`0x0011`)
+Process an authenticated encryption operation. Opcode: 17 (`0x0011`)
 
 ## Parameters
 

--- a/src/parsec_client/operations/psa_algorithm.md
+++ b/src/parsec_client/operations/psa_algorithm.md
@@ -121,7 +121,7 @@ Asymmetric signature algorithms. Supported algorithms:
 
 - **RSA PKCS#1 v1.5 signature with hashing.** This is the signature scheme defined by [RFC
    8017](https://tools.ietf.org/html/rfc8017.html) (PKCS#1: RSA Cryptography Specifications) under
-   the name RSASSA-PKCS1-v1_5. Uses one of the hash algorithm supported.
+   the name `RSASSA-PKCS1-v1_5`. Uses one of the hash algorithm supported.
 - **Raw PKCS#1 v1.5 signature.** The input to this algorithm is the DigestInfo structure used by
    [RFC 8017](https://tools.ietf.org/html/rfc8017.html) §9.2 (PKCS#1: RSA Cryptography
    Specifications), in steps 3–6.

--- a/src/parsec_client/operations/psa_export_key.md
+++ b/src/parsec_client/operations/psa_export_key.md
@@ -27,25 +27,27 @@ that is equivalent to key.
 
 For standard key types, the output format is as follows:
 
-- For symmetric keys, including MAC keys, the format is the raw bytes of the key.
+- For symmetric keys, including HMAC keys, the format is the raw bytes of the key.
 - For [`DES`](psa_key_attributes.md#des-type), the key data consists of 8 bytes. The parity bits
    must be correct.
 - For [`Triple-DES`](psa_key_attributes.md#des-type), the format is the concatenation of the two or
    three DES keys.
 - For RSA key pairs, with key type [`RsaKeyPair`](psa_key_attributes.md#rsakeypair-type), the format
-   is the non-encrypted DER encoding of the representation defined by PKCS#1 in [`RFC
-   8017`](https://tools.ietf.org/html/rfc8017.html) as RSAPrivateKey, version 0 (`[1]`).
+   is the non-encrypted DER encoding of the representation defined in *PKCS #1: RSA Cryptography
+   Specifications Version 2.2* [`RFC 8017`](https://tools.ietf.org/html/rfc8017.html) as
+   `RSAPrivateKey`, version 0 (`[1]`).
 - For elliptic curve key pairs, with key type [`EccKeyPair`](psa_key_attributes.md#ecckeypair-type),
    the format is a representation of the private value.
    - For Weierstrass curve families `sectXX`, `secpXX`, `FRP` and `Brainpool`, the content of the
-      privateKey field of the ECPrivateKey format defined by [`RFC
-      5915`](https://tools.ietf.org/html/rfc5915.html). This is a ceiling(m/8)-byte string in
-      big-endian order where m is the key size in bits.
+      `privateKey` field of the `ECPrivateKey` format defined by *Elliptic Curve Private Key
+      Structure* [`RFC 5915`](https://tools.ietf.org/html/rfc5915.html). This is a
+      `ceiling(m/8)`-byte string in big-endian order where `m` is the key size in bits.
    - For Montgomery curve family, the scalar value of the ‘private key’ in little-endian order
-      as defined by [RFC 7748 §6](https://tools.ietf.org/html/rfc7748.html#section-6). This is a
-      `ceiling(m/8)`-byte string where `m` is the key size in bits.
-      - This is 32 bytes for Curve25519, computed as `X25519(private_key, 9)`.
-      - This is 56 bytes for Curve448, computed as `X448(private_key, 5)`.
+      as defined by *Elliptic Curves for Security* [RFC 7748
+      §6](https://tools.ietf.org/html/rfc7748.html#section-6). The value must have the forced bits
+      set to zero or one as specified by `decodeScalar25519()` and `decodeScalar448()` in [RFC7748
+      §5](https://tools.ietf.org/html/rfc7748.html#section-5). This is a `ceiling(m/8)`-byte string
+      where `m` is the key size in bits. This is 32 bytes for Curve25519, and 56 bytes for Curve448.
 - For Diffie-Hellman key exchange key pairs, with key types
    [DhKeyPair](psa_key_attributes.md#dhkeypair-type), the format is the representation of the
    private key `x` as a big-endian byte string. The length of the byte string is the private key
@@ -56,17 +58,16 @@ For standard key types, the output format is as follows:
 
 ```
 RSAPrivateKey ::= SEQUENCE {
-             version           Version,
-             modulus           INTEGER,  -- n
-             publicExponent    INTEGER,  -- e
-             privateExponent   INTEGER,  -- d
-             prime1            INTEGER,  -- p
-             prime2            INTEGER,  -- q
-             exponent1         INTEGER,  -- d mod (p-1)
-             exponent2         INTEGER,  -- d mod (q-1)
-             coefficient       INTEGER,  -- (inverse of q) mod p
-             otherPrimeInfos   OtherPrimeInfos OPTIONAL
-         }
+    version           INTEGER,  -- must be 0
+    modulus           INTEGER,  -- n
+    publicExponent    INTEGER,  -- e
+    privateExponent   INTEGER,  -- d
+    prime1            INTEGER,  -- p
+    prime2            INTEGER,  -- q
+    exponent1         INTEGER,  -- d mod (p-1)
+    exponent2         INTEGER,  -- d mod (q-1)
+    coefficient       INTEGER,  -- (inverse of q) mod p
+}
 ```
 
 ## Contract

--- a/src/parsec_client/operations/psa_export_public_key.md
+++ b/src/parsec_client/operations/psa_export_public_key.md
@@ -26,23 +26,26 @@ that is equivalent to the public key.
 For standard key types, the output format is as follows:
 
 - For RSA public keys, with key type [`RsaPublicKey`](psa_key_attributes.md#rsapublickey-type), the
-   DER encoding of the representation defined by [RFC 3279
+   DER encoding of the representation defined by *Algorithms and Identifiers for the Internet X.509
+   Public Key Infrastructure Certifiate and Certificate Revocation List (CRL) Profile* [RFC 3279
    §2.3.1](https://tools.ietf.org/html/rfc3279.html#section-2.3.1) as `RSAPublicKey` (`[1]`).
 - For elliptic curve public keys, with key type
    [`EccPublicKey`](psa_key_attributes.md#eccpublickey-type), the format depends on the [curve
    family](psa_key_attributes.md#supported-ecc-curve-families):
    - For Weierstrass curve families sectXX, secpXX, FRP and Brainpool, the uncompressed
-      representation defined by *Standards for Efficient Cryptography, SEC 1: Elliptic Curve
-      Cryptography* §2.3.3 as the content of an `ECPoint`. If `m` is the bit size associated with
-      the curve, i.e. the bit size of `q` for a curve over `F_q`. The representation consists of:
-   - The byte `0x04`;
-   - `x_P` as a `ceiling(m/8)`-byte string, big-endian;
-   - `y_P` as a `ceiling(m/8)`-byte string, big-endian.
+      representation of an elliptic curve point as an octet string defined in *SEC 1: Elliptic Curve
+      Cryptography* [SEC1](https://www.secg.org/sec1-v2.pdf) §2.3.3. If `m` is the bit size
+      associated with the curve, i.e. the bit size of `q` for a curve over `F_q`. The representation
+      consists of:
+      - The byte `0x04`;
+      - `x_P` as a `ceiling(m/8)`-byte string, big-endian;
+      - `y_P` as a `ceiling(m/8)`-byte string, big-endian.
    - For Montgomery curve family, the scalar value of the ‘public key’ in little-endian order as
-      defined by [RFC 7748 §6](https://tools.ietf.org/html/rfc7748.html#section-6). This is a
-      `ceiling(m/8)`-byte string where `m` is the key size in bits.
-   - This is 32 bytes for Curve25519, computed as `X25519(private_key, 9)`.
-   - This is 56 bytes for Curve448, computed as `X448(private_key, 5)`.
+      defined by *Elliptic Curves for Security* [RFC 7748
+      §6](https://tools.ietf.org/html/rfc7748.html#section-6). This is a `ceiling(m/8)`-byte string
+      where `m` is the key size in bits.
+      - This is 32 bytes for Curve25519, computed as `X25519(private_key, 9)`.
+      - This is 56 bytes for Curve448, computed as `X448(private_key, 5)`.
 - For Diffie-Hellman key exchange public keys, with key types
    [DhPublicKey](psa_key_attributes.md#dhpublickey-type), the format is the representation of the
    public key `y = g^x mod p` as a big-endian byte string. The length of the byte string is the

--- a/src/parsec_client/operations/psa_generate_key.md
+++ b/src/parsec_client/operations/psa_generate_key.md
@@ -9,6 +9,8 @@ Generate a key or key pair. Opcode: 2 (`0x0002`)
 | `key_name`   | String                                                      | Name of the key to generate   |
 | `attributes` | [`KeyAttributes`](psa_key_attributes.md#keyattributes-type) | The attributes of the new key |
 
+- The `key_type` field of `attributes` can not be an asymmetric public key.
+
 ## Results
 
 No values are returned by this operation.
@@ -16,6 +18,8 @@ No values are returned by this operation.
 ## Specific response status codes
 
 - `PsaErrorAlreadyExists`: There is already a key with the given name.
+- `PsaErrorNotSupported`: The key type or key size is not supported.
+- `PsaErrorInvalidArgument`: The key attributes, as a whole, are invalid.
 
 ## Description
 
@@ -24,8 +28,8 @@ The key is generated randomly. Its location, policy, type and size are taken fro
 The following type-specific considerations apply:
 
 - For RSA keys (key type is [`RsaKeyPair`](psa_key_attributes.md#rsakeypair-type)), the public
-   exponent is 65537. The modulus is a product of two probabilistic primes between 2^{n-1} and 2^n
-   where n is the bit size specified in the attributes.
+   exponent is `65537`. The modulus is a product of two probabilistic primes between `2^{n-1}` and
+   `2^n` where `n` is the bit size specified in the attributes.
 
 ## Contract
 


### PR DESCRIPTION
Which is the newest version of PSA Crypto.

Part of #90

Note that PSA Crypto 1.0.1 also added `PSA_ALG_SM3` and `PSA_KEY_TYPE_SM4` (full diff [here](https://armmbed.github.io/mbed-crypto/html/appendix/history.html)).
If we wanted to support those new alg/key type, we would have to modify our contract to add new variants in the `oneof` field. I am not sure if adding it would be a breaking change or not ([related](https://developers.google.com/protocol-buffers/docs/proto3#oneof)). It will definitely be a breaking change in the Parsec Rust Interface as those as strongly typed enums but it might be fine there? Maybe worth opening an issue for it.