### PR TITLE
Add key attestation operations

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,8 @@
 ![Parsec Logo](parsec.png)
 
-**Parsec** is the **P**latform **A**bst**R**action for **SEC**urity, a new open-source initiative to
-provide a common API to secure services in a platform-agnostic way.
+**Parsec** is the **P**latform **A**bst**R**action for **SEC**urity, an open-source initiative to
+provide a common API to secure services in a platform-agnostic way. Parsec is a [Cloud Native
+Compute Foundation Sandbox](https://www.cncf.io/sandbox-projects/) project.
 
 Find here all the technical documentation of Parsec, alongside user and developer guides.
 
@@ -10,8 +11,9 @@ Go straight to the [overview](overview.md) to learn more about the project!
 Check out the [Getting Started guides](getting_started) to quickly try out Parsec!
 
 Then, depending on what you want to know, you can go to the [users](parsec_users.md), [client
-developers](parsec_client/README.md), [service developers](parsec_service/README.md) or
-[security](parsec_security/README.md) sections.
+developers](https://parallaxsecond.github.io/parsec-book/parsec_client/index.html), [service
+developers](https://parallaxsecond.github.io/parsec-book/parsec_service/index.html) or
+[security](https://parallaxsecond.github.io/parsec-book/parsec_security/index.html) sections.
 
 Don't hesitate to ask any question you would have when reading on our [Community Slack
 Channel](https://github.com/parallaxsecond/community#community-channel)!

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -43,6 +43,11 @@
       - [ListKeys](parsec_client/operations/list_keys.md)
       - [ListClients](parsec_client/operations/list_clients.md)
       - [DeleteClient](parsec_client/operations/delete_client.md)
+      - [Prepare Key Attestation
+         Parameters](parsec_client/operations/prepare_key_attestation_params.md)
+      - [PrepareKeyAttestation](parsec_client/operations/prepare_key_attestation.md)
+      - [AttestKey](parsec_client/operations/attest_key.md)
+      - [Attest Key Parameters](parsec_client/operations/attest_key_params.md)
 - [Parsec for service developers](parsec_service/README.md)
    - [Interfaces and Dataflow](parsec_service/interfaces_and_dataflow.md)
    - [Source Code Structure](parsec_service/source_code_structure.md)

--- a/src/parsec_client/operations/README.md
+++ b/src/parsec_client/operations/README.md
@@ -8,36 +8,38 @@ translated to the specific operation implementation language used.
 
 ## Overview
 
-| Operation                                         | Opcode   |
-|---------------------------------------------------|----------|
-| [Ping](ping.md)                                   | `0x0001` |
-| [PsaGenerateKey](psa_generate_key.md)             | `0x0002` |
-| [PsaDestroyKey](psa_destroy_key.md)               | `0x0003` |
-| [PsaSignHash](psa_sign_hash.md)                   | `0x0004` |
-| [PsaVerifyHash](psa_verify_hash.md)               | `0x0005` |
-| [PsaImportKey](psa_import_key.md)                 | `0x0006` |
-| [PsaExportPublicKey](psa_export_public_key.md)    | `0x0007` |
-| [ListProviders](list_providers.md)                | `0x0008` |
-| [ListOpcodes](list_opcodes.md)                    | `0x0009` |
-| [PsaAsymmetricEncrypt](psa_asymmetric_encrypt.md) | `0x000A` |
-| [PsaAsymmetricDecrypt](psa_asymmetric_decrypt.md) | `0x000B` |
-| [PsaExportKey](psa_export_key.md)                 | `0x000C` |
-| [PsaGenerateRandom](psa_generate_random.md)       | `0x000D` |
-| [ListAuthenticators](list_authenticators.md)      | `0x000E` |
-| [PsaHashCompute](psa_hash_compute.md)             | `0x000F` |
-| [PsaHashCompare](psa_hash_compare.md)             | `0x0010` |
-| [PsaAeadEncrypt](psa_aead_encrypt.md)             | `0x0011` |
-| [PsaAeadDecrypt](psa_aead_decrypt.md)             | `0x0012` |
-| [PsaRawKeyAgreement](psa_raw_key_agreement.md)    | `0x0013` |
-| [PsaCipherEncrypt](psa_cipher_encrypt.md)         | `0x0014` |
-| [PsaCipherDecrypt](psa_cipher_decrypt.md)         | `0x0015` |
-| [PsaMacCompute](psa_mac_compute.md)               | `0x0016` |
-| [PsaMacVerify](psa_mac_verify.md)                 | `0x0017` |
-| [PsaSignMessage](psa_sign_message.md)             | `0x0018` |
-| [PsaVerifyMessage](psa_verify_message.md)         | `0x0019` |
-| [ListKeys](list_keys.md)                          | `0x001A` |
-| [ListClients](list_clients.md)                    | `0x001B` |
-| [DeleteClient](delete_client.md)                  | `0x001C` |
+| Operation                                           | Opcode   |
+|-----------------------------------------------------|----------|
+| [Ping](ping.md)                                     | `0x0001` |
+| [PsaGenerateKey](psa_generate_key.md)               | `0x0002` |
+| [PsaDestroyKey](psa_destroy_key.md)                 | `0x0003` |
+| [PsaSignHash](psa_sign_hash.md)                     | `0x0004` |
+| [PsaVerifyHash](psa_verify_hash.md)                 | `0x0005` |
+| [PsaImportKey](psa_import_key.md)                   | `0x0006` |
+| [PsaExportPublicKey](psa_export_public_key.md)      | `0x0007` |
+| [ListProviders](list_providers.md)                  | `0x0008` |
+| [ListOpcodes](list_opcodes.md)                      | `0x0009` |
+| [PsaAsymmetricEncrypt](psa_asymmetric_encrypt.md)   | `0x000A` |
+| [PsaAsymmetricDecrypt](psa_asymmetric_decrypt.md)   | `0x000B` |
+| [PsaExportKey](psa_export_key.md)                   | `0x000C` |
+| [PsaGenerateRandom](psa_generate_random.md)         | `0x000D` |
+| [ListAuthenticators](list_authenticators.md)        | `0x000E` |
+| [PsaHashCompute](psa_hash_compute.md)               | `0x000F` |
+| [PsaHashCompare](psa_hash_compare.md)               | `0x0010` |
+| [PsaAeadEncrypt](psa_aead_encrypt.md)               | `0x0011` |
+| [PsaAeadDecrypt](psa_aead_decrypt.md)               | `0x0012` |
+| [PsaRawKeyAgreement](psa_raw_key_agreement.md)      | `0x0013` |
+| [PsaCipherEncrypt](psa_cipher_encrypt.md)           | `0x0014` |
+| [PsaCipherDecrypt](psa_cipher_decrypt.md)           | `0x0015` |
+| [PsaMacCompute](psa_mac_compute.md)                 | `0x0016` |
+| [PsaMacVerify](psa_mac_verify.md)                   | `0x0017` |
+| [PsaSignMessage](psa_sign_message.md)               | `0x0018` |
+| [PsaVerifyMessage](psa_verify_message.md)           | `0x0019` |
+| [ListKeys](list_keys.md)                            | `0x001A` |
+| [ListClients](list_clients.md)                      | `0x001B` |
+| [DeleteClient](delete_client.md)                    | `0x001C` |
+| [AttestKey](attest_key.md)                          | `0x001E` |
+| [PrepareKeyAttestation](prepare_key_attestation.md) | `0x001F` |
 
 Find [here](service_api_coverage.md) the current level of support of those operations in Parsec.
 
@@ -117,5 +119,18 @@ Most of the documentation in this book directly come from the specification.
 ### Random Number Generation
 
 - [PsaGenerateRandom](psa_generate_random.md)
+
+## Other operations
+
+These operations are not derived from PSA Crypto, but nonetheless perform tasks with backing from
+hardware tokens.
+
+### Key attestation
+
+**(EXPERIMENTAL) These operations are in an experimental phase. No guarantees are offered around the
+stability of their contracts or abstract interfaces.**
+
+- [PrepareKeyAttestation](prepare_key_attestation.md)
+- [AttestKey](attest_key.md)
 
 *Copyright 2019 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/attest_key.md
+++ b/src/parsec_client/operations/attest_key.md
@@ -1,0 +1,60 @@
+# AttestKey
+
+Attest that a Parsec-managed key is protected by a hardware backend. Opcode: 30 (`0x001E`)
+
+**(EXPERIMENTAL) This operation is in an experimental phase. No guarantees are offered around the
+stability of the contracts and abstract definition of the operation, or of any associated key
+attestation mechanism.**
+
+## Parameters
+
+| Name                 | Type                                                 | Description                               |
+|----------------------|------------------------------------------------------|-------------------------------------------|
+| `attested_key_name`  | String                                               | Name of the key to attest                 |
+| `parameters`         | [`AttestationMechanismParams`](attest_key_params.md) | Attestation mechanism-specific parameters |
+| `attesting_key_name` | String                                               | Name of the key to use for attesting      |
+
+- The exact usage flags required by the attesting key are determined by the mechanism used, also
+   described on the [key attestation parameters page](attest_key_params.md).
+
+## Results
+
+| Name     | Type                                        | Description                           |
+|----------|---------------------------------------------|---------------------------------------|
+| `output` | [`AttestationOutput`](attest_key_params.md) | Attestation mechanism-specific output |
+
+## Specific response status codes
+
+TBD
+
+## Description
+
+This operation performs a key attestation using a mechanism supported by the backend holding the
+key. The purpose of the operation is to help a Parsec client provide proof to a 3rd party that some
+key provisioned by the client is indeed stored and secured by a hardware backend. As such, the
+operation is backed by native functionality in the hardware to attest to ownership of the key.
+
+Given the wide variety of possible mechanisms, many of the properties, restrictions, and formats
+involved are mechanism-dependent, including:
+
+- Properties of the attested key (e.g. whether it was created within the backend or imported)
+- Properties of the attesting key (e.g. if it must be able to sign or decrypt)
+- Number, content, and purpose of parameters required by the attestation
+- Contents and format of the output
+- Whether or not the attesting key can be specified
+
+All such characteristics are thoroughly described per mechanism on the [key attestation parameters
+page](attest_key_params.md).
+
+All instances of backends that support `AttestKey` must be configured with a default, root key that
+has been pre-provisioned and which can be used to produce attestations. This default attesting key
+is selected by leaving the `attesting_key_name` empty. If the backend allows other keys to be used
+for attesting, attestation chains can be created starting from the root key.
+
+`AttestKey` applies to asymmetric key pairs only.
+
+## Contract
+
+TBD
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/attest_key_params.md
+++ b/src/parsec_client/operations/attest_key_params.md
@@ -1,0 +1,66 @@
+# Key Attestation Parameters
+
+This page defines the mechanism-specific inputs and outputs of `AttestKey`. For an in-depth look at
+the mechanisms and hardware tokens that we've considered, you can read our write-up
+[here](https://drive.google.com/file/d/11jLLv8zN_xRunj9BEkk_L_tj5DiQOtkG/view?usp=sharing).
+
+Each mechanism comes with its own definitions for `AttestationMechanismParams` and
+`AttestationOutput`.
+
+**(EXPERIMENTAL) The parameters for key attestation are in an experimental phase. No guarantees are
+offered around the stability of the interface for any key attestation mechanism.**
+
+## Activate Credential (TPM provider) {#activatecredential}
+
+The [TPM 2.0 Commands
+spec](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf)
+describes the `TPM2_ActivateCredential` operation as follows:
+
+> This command enables the association of a credential with an object in a way that ensures that the
+> TPM has validated the parameters of the credentialed object.
+
+`TPM2_ActivateCredential` allows a 3rd party to be assured of the protection of a key by means of an
+encrypted credential. The 3rd party produces a random credential and encrypts it using the algorithm
+defined in the [TPM 2.0 Architecture
+spec](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf),
+section B.10.4. The outputs of that algorithm (the encrypted and HMAC-protected credential, and a
+secret seed encrypted with the public part of the attesting key) are sent to the Parsec service
+which proceeds to perform the operation and returns the decrypted credential. The 3rd party can then
+be certain that the key is protected by a TPM by confirming that the credential sent and the one
+received are identical.
+
+The computation mentioned previously relies on a number of parameters that must be obtained from the
+Parsec service. As some of these parameters are strictly TPM-specific, they can be retrieved with
+the [`PrepareKeyAttestation`](prepare_key_attestation.md) operation. You can see how to perform the
+preparation step for `ActivateCredential`
+[here](prepare_key_attestation_params.md#activatecredential).
+
+**This mechanisms is thus aimed at attesting keys that are configured for decryption** (as opposed
+to signing) and is of particular interest because the Endorsement Keys for which TPM manufacturers
+produce certificates are overwhelmingly decryption keys.
+
+The parameters and output follow the inputs and outputs of `TPM2_ActivateCredential` as defined in
+the [TPM 2.0 Structures
+spec](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf).
+
+### AttestationMechanismParams
+
+| Name              | Type                     | Description                    |
+|-------------------|--------------------------|--------------------------------|
+| `credential_blob` | Vector of unsigned bytes | Protected credential           |
+| `secret`          | Vector of unsigned bytes | Attesting key-encrypted secret |
+
+- `credential_blob` represents the contents of the `credential` field within the `TPM2B_ID_OBJECT`
+   structure.
+- `secret` represents the contents of the `secret` field within the `TPM2B_ENCRYPTED_SECRET`
+   structure.
+
+### AttestationOutput
+
+| Name         | Type                     | Description                    |
+|--------------|--------------------------|--------------------------------|
+| `credential` | Vector of unsigned bytes | Credential returned by the TPM |
+
+- `credential` represents the contents of the `buffer` field within the `TPM2B_DIGEST` structure.
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/prepare_key_attestation.md
+++ b/src/parsec_client/operations/prepare_key_attestation.md
@@ -1,0 +1,40 @@
+# PrepareKeyAttestation
+
+Prepare the backend for performing a key attestation with a given algorithm and retrieve any data
+necessary prior to the attestation operation. Opcode: 31 (`0x001F`)
+
+**(EXPERIMENTAL) This operation is in an experimental phase. No guarantees are offered around the
+stability of the contracts.**
+
+## Parameters
+
+| Name         | Type                                                               | Description                               |
+|--------------|--------------------------------------------------------------------|-------------------------------------------|
+| `parameters` | [`PrepareKeyAttestationParams`](prepare_key_attestation_params.md) | Attestation mechanism-specific parameters |
+
+## Results
+
+| Name     | Type                                                               | Description                           |
+|----------|--------------------------------------------------------------------|---------------------------------------|
+| `output` | [`PrepareKeyAttestationOutput`](prepare_key_attestation_params.md) | Attestation mechanism-specific output |
+
+## Specific response status codes
+
+TBD
+
+## Description
+
+This operation performs any preparation steps required by the `AttestKey` operation. These steps are
+attestation-mechanism specific and can include performing any service-side setup, as well as
+obtaining any data necessary to the client or 3rd party requesting the attestation.
+
+**NOTE:** Only some of the attestation mechanisms require preparation. You can check which ones do
+in their descriptions on the [key attestation parameters page](attest_key_params.md). Their
+corresponding preparation parameters can be found on the [key attestation preparation parameters
+page](prepare_key_attestation_params.md).
+
+## Contract
+
+TBD
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/prepare_key_attestation_params.md
+++ b/src/parsec_client/operations/prepare_key_attestation_params.md
@@ -1,0 +1,56 @@
+# Prepare Key Attestation Parameters
+
+This page defines the mechanism-specific inputs and outputs of `PrepareKeyAttestation`. For an
+in-depth look at the mechanisms and hardware tokens that we've considered, you can read our write-up
+[here](https://drive.google.com/file/d/11jLLv8zN_xRunj9BEkk_L_tj5DiQOtkG/view?usp=sharing).
+
+Each mechanism that needs preparation comes with its own definitions for
+`PrepareKeyAttestationParams` and `PrepareKeyAttestationOutput`.
+
+**(EXPERIMENTAL) The parameters for key attestation are in an experimental phase. No guarantees are
+offered around the stability of the interface for any key attestation mechanism.**
+
+## ActivateCredential (TPM provider) {#activatecredential}
+
+The preparation necessary for `ActivateCredential` involves retrieving the data necessary for
+performing the `TPM2_MakeCredential` computations outside of a TPM. The results from
+`MakeCredential` can then be passed to `AttestKey`.
+
+The service returns the TPM-specific name of the object to be attested, its public parameters, and
+the public part of the attesting key. These three components can then be used by a 3rd party to
+generate an encrypted credential to be used in `AttestKey`. The algorithm for protecting the
+credential is defined in the [TPM 2.0 Architecture
+spec](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part1_Architecture_pub.pdf),
+section B.10.4.
+
+The public parameters of the key which will be attested are not strictly necessary in generating the
+encrypted credential. The reason for its inclusion, however, rests on the need of the 3rd party to
+verify that the object they are about to attest is indeed the one they expect. The process of
+encrypting the credential involves deriving a symmetric key using the TPM-specific name of the
+object to be attested. This name is obtained by performing a hash over the public parameters of the
+object, and can thus be verified by the 3rd party if those parameters are available.
+
+### PrepareKeyAttestationParams
+
+| Name                 | Type   | Description                          |
+|----------------------|--------|--------------------------------------|
+| `attested_key_name`  | String | Name of the key to be attested       |
+| `attesting_key_name` | String | Name of the key to use for attesting |
+
+- if `attesting_key_name` is empty, the default key for the `ActivateCredential` mechanism will be
+   used
+
+### PrepareKeyAttestationOutput
+
+| Name                | Type                     | Description                                            |
+|---------------------|--------------------------|--------------------------------------------------------|
+| `name`              | Vector of unsigned bytes | TPM-specific name of the key object to be attested     |
+| `public`            | Vector of unsigned bytes | Public parameters of the key object to be attested     |
+| `attesting_key_pub` | Vector of unsigned bytes | Buffer containing the public part of the attesting key |
+
+- `name` represents the contents of the `name` field within the `TPM2B_NAME` structure.
+- `public` represents the contents of the `publicArea` field within the `TPM2B_PUBLIC` structure.
+- `attesting_key_pub` represents a public key encoded in the format specified for
+   [`PsaExportPublicKey`](psa_export_public_key.md)
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/src/parsec_client/operations/service_api_coverage.md
+++ b/src/parsec_client/operations/service_api_coverage.md
@@ -7,36 +7,38 @@ table.
 Not all parameters (key types, algorithms) of the operation might be supported. See the following
 sections for details.
 
-| Operation \ Provider                              | Core | Mbed Crypto | PKCS 11 | TPM 2.0 | Trusted Service | CryptoAuth library |
-|---------------------------------------------------|------|-------------|---------|---------|-----------------|--------------------|
-| [Ping](ping.md)                                   | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [ListProviders](list_providers.md)                | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [ListOpcodes](list_opcodes.md)                    | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [ListAuthenticators](list_authenticators.md)      | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [ListKeys](list_keys.md)                          | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [DeleteClient](delete_client.md)                  | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [ListClients](list_clients.md)                    | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
-| [PsaImportKey](psa_import_key.md)                 | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
-| [PsaGenerateKey](psa_generate_key.md)             | ❎  | ✅         | ✅     | ✅     | ✅             | ✅                |
-| [PsaDestroyKey](psa_destroy_key.md)               | ❎  | ✅         | ✅     | ✅     | ✅             | ✅                |
-| [PsaExportKey](psa_export_key.md)                 | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
-| [PsaExportPublicKey](psa_export_public_key.md)    | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
-| [PsaHashCompute](psa_hash_compute.md)             | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
-| [PsaHashCompare](psa_hash_compare.md)             | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
-| [PsaMacCompute](psa_mac_compute.md)               | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaMacVerify](psa_mac_verify.md)                 | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaCipherEncrypt](psa_cipher_encrypt.md)         | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaCipherDecrypt](psa_cipher_decrypt.md)         | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaAeadEncrypt](psa_aead_encrypt.md)             | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
-| [PsaAeadDecrypt](psa_aead_decrypt.md)             | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
-| [PsaSignMessage](psa_sign_message.md)             | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaVerifyMessage](psa_verify_message.md)         | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
-| [PsaSignHash](psa_sign_hash.md)                   | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
-| [PsaVerifyHash](psa_verify_hash.md)               | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
-| [PsaAsymmetricEncrypt](psa_asymmetric_encrypt.md) | ❎  | ✅         | ✅     | ✅     | ❌             | ❌                |
-| [PsaAsymmetricDecrypt](psa_asymmetric_decrypt.md) | ❎  | ✅         | ✅     | ✅     | ❌             | ❌                |
-| [PsaRawKeyAgreement](psa_raw_key_agreement.md)    | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
-| [PsaGenerateRandom](psa_generate_random.md)       | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
+| Operation \ Provider                                | Core | Mbed Crypto | PKCS 11 | TPM 2.0 | Trusted Service | CryptoAuth library |
+|-----------------------------------------------------|------|-------------|---------|---------|-----------------|--------------------|
+| [Ping](ping.md)                                     | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [ListProviders](list_providers.md)                  | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [ListOpcodes](list_opcodes.md)                      | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [ListAuthenticators](list_authenticators.md)        | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [ListKeys](list_keys.md)                            | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [DeleteClient](delete_client.md)                    | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [ListClients](list_clients.md)                      | ✅  | ❎         | ❎     | ❎     | ❎             | ❎                |
+| [PsaImportKey](psa_import_key.md)                   | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
+| [PsaGenerateKey](psa_generate_key.md)               | ❎  | ✅         | ✅     | ✅     | ✅             | ✅                |
+| [PsaDestroyKey](psa_destroy_key.md)                 | ❎  | ✅         | ✅     | ✅     | ✅             | ✅                |
+| [PsaExportKey](psa_export_key.md)                   | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
+| [PsaExportPublicKey](psa_export_public_key.md)      | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
+| [PsaHashCompute](psa_hash_compute.md)               | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
+| [PsaHashCompare](psa_hash_compare.md)               | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
+| [PsaMacCompute](psa_mac_compute.md)                 | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaMacVerify](psa_mac_verify.md)                   | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaCipherEncrypt](psa_cipher_encrypt.md)           | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaCipherDecrypt](psa_cipher_decrypt.md)           | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaAeadEncrypt](psa_aead_encrypt.md)               | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
+| [PsaAeadDecrypt](psa_aead_decrypt.md)               | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
+| [PsaSignMessage](psa_sign_message.md)               | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaVerifyMessage](psa_verify_message.md)           | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PsaSignHash](psa_sign_hash.md)                     | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
+| [PsaVerifyHash](psa_verify_hash.md)                 | ❎  | ✅         | ✅     | ✅     | ✅             | ❌                |
+| [PsaAsymmetricEncrypt](psa_asymmetric_encrypt.md)   | ❎  | ✅         | ✅     | ✅     | ❌             | ❌                |
+| [PsaAsymmetricDecrypt](psa_asymmetric_decrypt.md)   | ❎  | ✅         | ✅     | ✅     | ❌             | ❌                |
+| [PsaRawKeyAgreement](psa_raw_key_agreement.md)      | ❎  | ✅         | ❌     | ❌     | ❌             | ❌                |
+| [PsaGenerateRandom](psa_generate_random.md)         | ❎  | ✅         | ❌     | ❌     | ❌             | ✅                |
+| [AttestKey](attest_key.md)                          | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
+| [PrepareKeyAttestation](prepare_key_attestation.md) | ❎  | ❌         | ❌     | ❌     | ❌             | ❌                |
 
 - ✅: The provider supports the operation (maybe not all of its parameters, check below).
 - ❎: The operation is not meant to be implemented on this provider (core operation on a crypto


### PR DESCRIPTION
This commit adds documentation for two new operations: AttestKey, used
for generating proofs that some key provisioned through Parsec is indeed
by the claimed hardware; GetMakeCredParams, used to prepare the
parameters for one of the mechanisms used within AttestKey (namely,
ActivateCredential in the TPM provider).

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>