### PR TITLE
Remove stability guarantee of Mbed Crypto/Mbed TLS

### DIFF
--- a/src/parsec_service/stability.md
+++ b/src/parsec_service/stability.md
@@ -87,6 +87,8 @@ We use the specific versions of those dynamic libraries and test it on CI:
 - PKCS#11 version 2.40
 - libclang version 6.0
 - TSS libraries version 2.3.3
-- Mbed TLS version 2.25.0
+
+Mbed Crypto is currently compiled from scratch. When a new LTS version of Mbed TLS ships a PSA
+Crypto compliant version of Mbed Crypto, stability guarantees will be made on that version.
 
 *Copyright 2021 Contributors to the Parsec project.*


### PR DESCRIPTION
See https://github.com/parallaxsecond/rust-psa-crypto/pull/88 for details.