### PR TITLE
Add [Quickstart for openSUSE and SUSE] in Summary

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Overview](overview.md)
 - [Getting Started](getting_started/README.md)
    - [Quickstart for Linux on x86](getting_started/linux_x86.md)
+   - [Quickstart for openSUSE and SUSE](getting_started/opensuse.md)
    - [Quickstart using a Docker container](getting_started/docker.md)
 - [Parsec for users](parsec_users.md)
 - [Parsec for client developers](parsec_client/README.md)


### PR DESCRIPTION
This is a follow-up of https://github.com/parallaxsecond/parsec-book/pull/133