### PR TITLE
Update api coverage with pkcs11 generate random support

### DIFF
--- a/src/parsec_client/operations/service_api_coverage.md
+++ b/src/parsec_client/operations/service_api_coverage.md
@@ -36,7 +36,7 @@ sections for details.
 | [PsaAsymmetricEncrypt](psa_asymmetric_encrypt.md)   | 🚫    | ✅           | ✅       | ✅       | ✅               | ❌                  |
 | [PsaAsymmetricDecrypt](psa_asymmetric_decrypt.md)   | 🚫    | ✅           | ✅       | ✅       | ✅               | ❌                  |
 | [PsaRawKeyAgreement](psa_raw_key_agreement.md)      | 🚫    | ✅           | ❌       | ❌       | ❌               | ✅                  |
-| [PsaGenerateRandom](psa_generate_random.md)         | 🚫    | ✅           | ❌       | ❌       | ✅               | ✅                  |
+| [PsaGenerateRandom](psa_generate_random.md)         | 🚫    | ✅           | ✅       | ✅       | ✅               | ✅                  |
 | [AttestKey](attest_key.md)                          | 🚫    | ❌           | ❌       | ✅       | ❌               | ❌                  |
 | [PrepareKeyAttestation](prepare_key_attestation.md) | 🚫    | ❌           | ❌       | ✅       | ❌               | ❌                  |
 | [CanDoCrypto](can_do_crypto.md)                     | 🚫    | ✅           | ✅       | ✅       | ✅               | ❌                  |


### PR DESCRIPTION
The PKCS11 provider was enabled with generate random function
with #613 PR in parsec repo and TPM with #595. This patch reflects
the same in the document.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>