### PR TITLE
Add invalid padding warnings to decryption ops

### DIFF
--- a/src/overview.md
+++ b/src/overview.md
@@ -54,7 +54,7 @@ The following observations can be made about such applications:
 - They may be written with no explicit knowledge of the hardware capabilities of the target
    platform, such as whether an HSM or TPM is available.
 - They are often sharing the target platform hardware with other applications due to the use of
-   virtualisation or containerization technology.
+   virtualization or containerization technology.
 - The secure assets owned by one application must be isolated from those owned by another. For
    example, private keys provisioned on a hardware device must be isolated such that only the
    provisioning application would be able to perform subsequent operations with those keys.

--- a/src/overview.md
+++ b/src/overview.md
@@ -54,7 +54,7 @@ The following observations can be made about such applications:
 - They may be written with no explicit knowledge of the hardware capabilities of the target
    platform, such as whether an HSM or TPM is available.
 - They are often sharing the target platform hardware with other applications due to the use of
-   virtualization or containerization technology.
+   virtualisation or containerization technology.
 - The secure assets owned by one application must be isolated from those owned by another. For
    example, private keys provisioned on a hardware device must be isolated such that only the
    provisioning application would be able to perform subsequent operations with those keys.

--- a/src/parsec_client/operations/psa_asymmetric_decrypt.md
+++ b/src/parsec_client/operations/psa_asymmetric_decrypt.md
@@ -33,10 +33,11 @@ Decrypt a short message with a private key. Opcode: 11 (`0x000B`)
 
 This function will decrypt a short message with the private key of the provided key pair.
 
-**WARNING:** In some protocols, when decrypting data, it is essential that the behavior of the
-application does not depend on whether the padding is correct, down to precise timing. If the
-application must perform a decryption of unauthenticated data, the application writer must take care
-not to reveal whether the padding is invalid.
+**WARNING:** In some protocols, when decrypting data, it is essential that the behaviour of the
+application does not depend on whether the padding is correct (see
+[Bleichenbacher](https://link.springer.com/content/pdf/10.1007/bfb0055716.pdf)). If the application
+must perform a decryption of unauthenticated data, the application writer must take care not to
+reveal whether the padding is invalid.
 
 ## Contract
 

--- a/src/parsec_client/operations/psa_asymmetric_decrypt.md
+++ b/src/parsec_client/operations/psa_asymmetric_decrypt.md
@@ -33,7 +33,7 @@ Decrypt a short message with a private key. Opcode: 11 (`0x000B`)
 
 This function will decrypt a short message with the private key of the provided key pair.
 
-**WARNING:** In some protocols, when decrypting data, it is essential that the behaviour of the
+**WARNING:** In some protocols, when decrypting data, it is essential that the behavior of the
 application does not depend on whether the padding is correct (see
 [Bleichenbacher](https://link.springer.com/content/pdf/10.1007/bfb0055716.pdf)). If the application
 must perform a decryption of unauthenticated data, the application writer must take care not to

--- a/src/parsec_client/operations/psa_asymmetric_decrypt.md
+++ b/src/parsec_client/operations/psa_asymmetric_decrypt.md
@@ -27,10 +27,16 @@ Decrypt a short message with a private key. Opcode: 11 (`0x000B`)
 
 - `PsaErrorNotPermitted`: The key does not have the `decrypt` flag, or it does not permit the
    requested algorithm.
+- `PsaErrorInvalidPadding`: The decrypted padding is incorrect. See Warning below.
 
 ## Description
 
 This function will decrypt a short message with the private key of the provided key pair.
+
+**WARNING:** In some protocols, when decrypting data, it is essential that the behavior of the
+application does not depend on whether the padding is correct, down to precise timing. If the
+application must perform a decryption of unauthenticated data, the application writer must take care
+not to reveal whether the padding is invalid.
 
 ## Contract
 

--- a/src/parsec_client/operations/psa_cipher_decrypt.md
+++ b/src/parsec_client/operations/psa_cipher_decrypt.md
@@ -29,7 +29,7 @@ Decrypt a short message with a symmetric cipher. Opcode: 21 (`0x0015`)
 
 This function will decrypt a short message using the provided initialisation vector (IV).
 
-**Warning:** In some protocols, when decrypting data, it is essential that the behaviour of the
+**Warning:** In some protocols, when decrypting data, it is essential that the behavior of the
 application does not depend on whether the padding is correct (see [Klíma et
 al](https://eprint.iacr.org/2003/098.pdf)). Protocols that use authenticated encryption are
 recommended for use by applications, rather than plain encryption. If the application must perform a

--- a/src/parsec_client/operations/psa_cipher_decrypt.md
+++ b/src/parsec_client/operations/psa_cipher_decrypt.md
@@ -23,10 +23,17 @@ Decrypt a short message with a symmetric cipher. Opcode: 21 (`0x0015`)
 
 - `PsaErrorNotPermitted`: The key does not have the `decrypt` flag, or it does not permit the
    requested algorithm.
+- `PsaErrorInvalidPadding`: The decrypted padding is incorrect. See Warning below.
 
 ## Description
 
 This function will decrypt a short message using the provided initialisation vector (IV).
+
+**Warning:** In some protocols, when decrypting data, it is essential that the behavior of the
+application does not depend on whether the padding is correct, down to precise timing. Protocols
+that use authenticated encryption are recommended for use by applications, rather than plain
+encryption. If the application must perform a decryption of unauthenticated data, the application
+writer must take care not to reveal whether the padding is invalid.
 
 ## Contract
 

--- a/src/parsec_client/operations/psa_cipher_decrypt.md
+++ b/src/parsec_client/operations/psa_cipher_decrypt.md
@@ -29,11 +29,12 @@ Decrypt a short message with a symmetric cipher. Opcode: 21 (`0x0015`)
 
 This function will decrypt a short message using the provided initialisation vector (IV).
 
-**Warning:** In some protocols, when decrypting data, it is essential that the behavior of the
-application does not depend on whether the padding is correct, down to precise timing. Protocols
-that use authenticated encryption are recommended for use by applications, rather than plain
-encryption. If the application must perform a decryption of unauthenticated data, the application
-writer must take care not to reveal whether the padding is invalid.
+**Warning:** In some protocols, when decrypting data, it is essential that the behaviour of the
+application does not depend on whether the padding is correct (see [Klíma et
+al](https://eprint.iacr.org/2003/098.pdf)). Protocols that use authenticated encryption are
+recommended for use by applications, rather than plain encryption. If the application must perform a
+decryption of unauthenticated data, the application writer must take care not to reveal whether the
+padding is invalid.
 
 ## Contract
 


### PR DESCRIPTION
Adding `PsaErrorInvalidPadding` and a related warning on
`psa_asymmetric_decrypt` and `psa_cipher_decrypt` to notify clients of
the need for mitigations.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>