### PR TITLE
Update quickstart info and release version

### DIFF
--- a/src/getting_started/docker.md
+++ b/src/getting_started/docker.md
@@ -1,5 +1,6 @@
 # Docker
 
-TODO
+Please refer to the [installation
+guide](installation_options.md#option-3-use-a-quickstart-docker-image).
 
-*Copyright 2021 Contributors to the Parsec project.*
+*Copyright 2021-2023 Contributors to the Parsec project.*

--- a/src/getting_started/installation_options.md
+++ b/src/getting_started/installation_options.md
@@ -173,7 +173,7 @@ export PATH=${PATH}:$(pwd)/../bin
 Start the Parsec service with this command:
 
 ```
-./parsec &
+parsec &
 ```
 
 You should see some lines of console output as the service starts, ending with the following:
@@ -187,7 +187,7 @@ You should see some lines of console output as the service starts, ending with t
 You can now use the `parsec-tool` to check that the service is running:
 
 ```
-./parsec-tool ping
+parsec-tool ping
 ```
 
 If the Parsec components are correctly downloaded and running, you should see output similar to the

--- a/src/getting_started/installation_options.md
+++ b/src/getting_started/installation_options.md
@@ -124,16 +124,16 @@ ldd --version
 
 ### Download the Latest Quick-Start Release Bundle
 
-Run the following command to download and unpack the `quickstart-1.1.0-linux_x86_64` folder.
+Run the following command to download and unpack the `quickstart-1.2.0-linux_x86_64` folder.
 
 ```
-curl -s -N -L https://github.com/parallaxsecond/parsec/releases/download/1.1.0/quickstart-1.1.0-linux_x86_64.tar.gz | tar xz
+curl -s -N -L https://github.com/parallaxsecond/parsec/releases/download/1.2.0/quickstart-1.2.0-linux_x86_64.tar.gz | tar xz
 ```
 
 The resulting directory contains the following structure
 
 ```
-quickstart-1.1.0-linux_x86_64
+quickstart-1.2.0-linux_x86_64
 ├── bin
 │   ├── parsec                 # The parsec binary
 │   └── parsec-tool            # The parsec client tool
@@ -144,11 +144,11 @@ quickstart-1.1.0-linux_x86_64
     └── parsec-cli-tests.sh    # Standard parsec-tool tests
 ```
 
-The following examples assume you've navigated to the `quickstart-1.1.0-linux_x86_64/quickstart`
+The following examples assume you've navigated to the `quickstart-1.2.0-linux_x86_64/quickstart`
 directory, so let's do that now.
 
 ```
-cd quickstart-1.1.0-linux_x86_64/quickstart
+cd quickstart-1.2.0-linux_x86_64/quickstart
 ```
 
 ### Configure Your Environment

--- a/src/getting_started/parsec_tool_use.md
+++ b/src/getting_started/parsec_tool_use.md
@@ -11,8 +11,21 @@ cryptogpraohy. Use this short guide to get familiar with basic use of the most c
 
 ## Installing the Parsec Command-Line Tool
 
-To use this guide, you need to have `parsec-tool` installed or built. Use the Parsec [installation
-guide](installation_options.md) to learn how to do this.
+To use this guide, you need to have `parsec-tool` installed or built.
+
+For installing, use the following command:
+
+```
+cargo install parsec-tool
+```
+
+For building it, use the following commands:
+
+```
+git clone git@github.com:parallaxsecond/parsec-tool.git
+cd parsec-tool
+cargo build
+```
 
 To run the example commands in this guide, you will also need to ensure that the `parsec-tool`
 application is available on your `$PATH`. If you installed the tool using a package manager, then
@@ -485,7 +498,7 @@ The output will be similar to the following:
 ```
 [INFO ] Generating 8 random bytes...
 [INFO ] Random bytes:
-4B 9B FB 11 55 D9 7F 41 
+4B 9B FB 11 55 D9 7F 41
 ```
 
 Vary the `--nbytes` argument to generate random sequences of different sizes.

--- a/src/parsec_service/build_run.md
+++ b/src/parsec_service/build_run.md
@@ -36,7 +36,7 @@ at `/tmp/parsec.sock`. The test configuration will make those choices.
 Clone the Parsec service repo,
 
 ```
-git clone --branch 1.1.0 https://github.com/parallaxsecond/parsec.git
+git clone --branch 1.2.0 https://github.com/parallaxsecond/parsec.git
 ```
 
 Having cloned the Parsec repository, to build and run from source using the Mbed Crypto provider and

--- a/src/parsec_service/stability.md
+++ b/src/parsec_service/stability.md
@@ -23,7 +23,7 @@ without breaking anything. The only exception is for the communication channel w
 any version of the client library can successfully communicate with any version of the service.
 
 The principle of [semantic versioning](https://semver.org/) is used to describe the stability of
-Parsec versions and when breaking changes are done. If `parsec` version is at `1.1.0` then all
+Parsec versions and when breaking changes are done. If `parsec` version is at `1.2.0` then all
 future stable version to that will be `1.x.y`. Note that, although semver is used to describe Parsec
 stability, it is a strong goal for Parsec to remain stable at a `1.x.y` version. This document
 introduces the efforts that are made so that a `MAJOR` version bump should hopefully never happen.


### PR DESCRIPTION
This commit contains the following changes:
- The quickstart pages just have links to the installation guide. These are removed and installation page is renamed.
- References to 1.1.0 release is changed to 1.2.0

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>