### PR TITLE
Fix typos

### DIFF
--- a/src/getting_started/installation_options.md
+++ b/src/getting_started/installation_options.md
@@ -124,16 +124,16 @@ ldd --version
 
 ### Download the Latest Quick-Start Release Bundle
 
-Run the following command to download and unpack the `quickstart-1.2.0-linux_x86_64` folder.
+Run the following command to download and unpack the `quickstart-1.2.0-linux-x86_64` folder.
 
 ```
-curl -s -N -L https://github.com/parallaxsecond/parsec/releases/download/1.2.0/quickstart-1.2.0-linux_x86_64.tar.gz | tar xz
+curl -s -N -L https://github.com/parallaxsecond/parsec/releases/download/1.2.0/quickstart-1.2.0-linux-x86_64.tar.gz | tar xz
 ```
 
 The resulting directory contains the following structure
 
 ```
-quickstart-1.2.0-linux_x86_64
+quickstart-1.2.0-linux-x86_64
 ├── bin
 │   ├── parsec                 # The parsec binary
 │   └── parsec-tool            # The parsec client tool
@@ -144,11 +144,11 @@ quickstart-1.2.0-linux_x86_64
     └── parsec-cli-tests.sh    # Standard parsec-tool tests
 ```
 
-The following examples assume you've navigated to the `quickstart-1.2.0-linux_x86_64/quickstart`
+The following examples assume you've navigated to the `quickstart-1.2.0-linux-x86_64/quickstart`
 directory, so let's do that now.
 
 ```
-cd quickstart-1.2.0-linux_x86_64/quickstart
+cd quickstart-1.2.0-linux-x86_64/quickstart
 ```
 
 ### Configure Your Environment


### PR DESCRIPTION
Signed-off-by: Danish Raza <danish.raza@arm.com>

quickstart-1.2.0-linux-x86_64 incorrectly named quickstart-1.2.0-linux_x86_64 (erroneous underscore between linux and x86, should be a dash instead).