### PR TITLE
threat_model: Update Hardware Result Attacker

### DIFF
--- a/src/parsec_security/parsec_threat_model/threat_model.md
+++ b/src/parsec_security/parsec_threat_model/threat_model.md
@@ -233,7 +233,7 @@ can also create a spoofed hardware interface.
 
 |   | Description                                                                                                          | Mitigation          | Assets        |
 |---|----------------------------------------------------------------------------------------------------------------------|---------------------|---------------|
-| S | An attacker impersonates a hardware module or uses a malicious module plugged to the machine.                        | O-1, ASUM-2         | AS4, AS6      |
+| S | An attacker impersonates a hardware module or uses a malicious module plugged to the machine.                        | O-1, ASUM-1         | AS4, AS6, AS7 |
 | T | An attacker modifies the response of a hardware command.                                                             | O-8, U-3, M-10      | AS4, AS6      |
 | R | Responses cannot be proven to originate from the hardware module.                                                    | U-7                 |               |
 | I | An attacker can read the content of a command response.                                                              | U-3, M-10, O-8      | AS3, AS4, AS5 |


### PR DESCRIPTION
Add assumptions and mitigations to the attacker:

 * Assumption: For a hardware attacker, it does not make sense to assume as a mitigation that the SOFTWARE configuration has been done with correct permissions. We replace it with a HARDWARE assumption that only trusted agents can physically access the system.

 * Asset: We add the key mappings (and the wrapped TPM key) as a Hardware Result asset involved with this attacker.